### PR TITLE
Time management + handle go params

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,9 @@ fn main() {
                             }
                         }
                         Some("wtime") => {
-                            if pos.board().stm() == Color::White {
-                                if let Some(time_str) = tokens.next() {
-                                    if let Ok(time) = time_str.parse::<i32>() {
+                            if let Some(time_str) = tokens.next() {
+                                if let Ok(time) = time_str.parse::<i32>() {
+                                    if pos.board().stm() == Color::White {
                                         limits.use_clock = true;
                                         limits.time = time;
                                     }
@@ -133,9 +133,9 @@ fn main() {
                             }
                         }
                         Some("btime") => {
-                            if pos.board().stm() == Color::Black {
-                                if let Some(time_str) = tokens.next() {
-                                    if let Ok(time) = time_str.parse::<i32>() {
+                            if let Some(time_str) = tokens.next() {
+                                if let Ok(time) = time_str.parse::<i32>() {
+                                    if pos.board().stm() == Color::Black {
                                         limits.use_clock = true;
                                         limits.time = time;
                                     }
@@ -143,9 +143,9 @@ fn main() {
                             }
                         }
                         Some("winc") => {
-                            if pos.board().stm() == Color::White {
-                                if let Some(inc_str) = tokens.next() {
-                                    if let Ok(inc) = inc_str.parse::<i32>() {
+                            if let Some(inc_str) = tokens.next() {
+                                if let Ok(inc) = inc_str.parse::<i32>() {
+                                    if pos.board().stm() == Color::White {
                                         limits.use_clock = true;
                                         limits.inc = inc;
                                     }
@@ -153,16 +153,18 @@ fn main() {
                             }
                         }
                         Some("binc") => {
-                            if pos.board().stm() == Color::Black {
-                                if let Some(inc_str) = tokens.next() {
-                                    if let Ok(inc) = inc_str.parse::<i32>() {
+                            if let Some(inc_str) = tokens.next() {
+                                if let Ok(inc) = inc_str.parse::<i32>() {
+                                    if pos.board().stm() == Color::Black {
                                         limits.use_clock = true;
                                         limits.inc = inc;
                                     }
                                 }
                             }
                         }
-                        _ => { break; }
+                        _ => {
+                            break;
+                        }
                     }
                 }
                 let mv = searcher.run(limits, true, &pos);

--- a/src/search.rs
+++ b/src/search.rs
@@ -66,7 +66,7 @@ pub struct SearchLimits {
     pub inc: i32,
     pub max_depth: i32,
     pub max_time: i32,
-    pub max_nodes: i32
+    pub max_nodes: i32,
 }
 
 impl SearchLimits {
@@ -77,7 +77,7 @@ impl SearchLimits {
             inc: -1,
             max_depth: -1,
             max_time: -1,
-            max_nodes: -1
+            max_nodes: -1,
         }
     }
 }


### PR DESCRIPTION
```
Score of aquarii-tm vs aquarii-rep-detection: 63 - 5 - 21  [0.826] 89
...      aquarii-tm playing White: 32 - 1 - 12  [0.844] 45
...      aquarii-tm playing Black: 31 - 4 - 9  [0.807] 44
...      White vs Black: 36 - 32 - 21  [0.522] 89
Elo difference: 270.4 +/- 75.6, LOS: 100.0 %, DrawRatio: 23.6 %
SPRT: llr 2.98 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Gain is from searching for longer
Tested at stc on pohl.epd