### PR TITLE
PUCT with uniform policy

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use std::time::Instant;
 
-const BENCH_DEPTH: i32 = 3;
+const BENCH_DEPTH: i32 = 4;
 const BENCH_POSITIONS: [&'static str; 50] = [
     "r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14",
     "4rrk1/2p1b1p1/p1p3q1/4p3/2P2n1p/1P1NR2P/PB3PP1/3R1QK1 b - - 2 24",

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,10 +3,10 @@ use std::{ops::Range, time::Instant};
 use crate::{
     chess::{
         movegen::{movegen, MoveList},
-        Board, Move, ZobristKey,
+        Move,
     },
     position::Position,
-    types::{Color, Piece, PieceType},
+    types::PieceType,
 };
 
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -131,8 +131,9 @@ impl MCTS {
                         // 1 - child q because child q is from opposite perspective of current node
                         1.0 - child.q()
                     };
-                    let expl = ((node.visits as f32).ln() / (child.visits + 1) as f32).sqrt();
-                    let uct = q + Self::CUCT * expl;
+                    let policy = 1.0 / node.child_count as f32;
+                    let expl = (node.visits as f32).sqrt() / (1 + child.visits) as f32;
+                    let uct = q + Self::CUCT * policy * expl;
 
                     if uct > best_uct {
                         best_child_idx = child_idx;


### PR DESCRIPTION
```
Elo   | 581.66 +- 164.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.12 (-2.94, 2.94) [0.00, 10.00]
Games | N: 162 W: 151 L: 0 D: 11
Penta | [0, 0, 1, 9, 71]
```
https://mcthouacbb.pythonanywhere.com/test/386/

Bench: 4905698