### PR TITLE
Choose best move by greatest q instead of most visits

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -264,8 +264,8 @@ impl MCTS {
         let mut best_move = Move::NULL;
         for child_idx in root_node.child_indices() {
             let child_node = &self.nodes[child_idx as usize];
-            if child_node.q() > best_q {
-                best_q = child_node.q();
+            if 1.0 - child_node.q() > best_q {
+                best_q = 1.0 - child_node.q();
                 best_move = child_node.parent_move;
             }
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -260,12 +260,12 @@ impl MCTS {
 
     pub fn get_best_move(&self) -> Move {
         let root_node = &self.nodes[0];
-        let mut best_visits = 0;
+        let mut best_q = 0.0;
         let mut best_move = Move::NULL;
         for child_idx in root_node.child_indices() {
             let child_node = &self.nodes[child_idx as usize];
-            if child_node.visits > best_visits {
-                best_visits = child_node.visits;
+            if child_node.q() > best_q {
+                best_q = child_node.q();
                 best_move = child_node.parent_move;
             }
         }


### PR DESCRIPTION
```
Elo   | 41.44 +- 17.16 (95%)
SPRT  | 24.0+0.24s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 10.00]
Games | N: 556 W: 126 L: 60 D: 370
Penta | [3, 42, 137, 78, 18]
```
https://mcthouacbb.pythonanywhere.com/test/402/

Bench: 16679518