### PR TITLE
Higher root CPUCT

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -138,7 +138,8 @@ pub struct MCTS {
 }
 
 impl MCTS {
-    const CUCT: f32 = std::f32::consts::SQRT_2;
+    const ROOT_CPUCT: f32 = 2.21858038;
+    const CPUCT: f32 = std::f32::consts::SQRT_2;
     const EVAL_SCALE: f32 = 200.0;
 
     pub fn new(max_nodes: u32) -> Self {
@@ -183,7 +184,12 @@ impl MCTS {
                     };
                     let policy = child.policy;
                     let expl = (node.visits as f32).sqrt() / (1 + child.visits) as f32;
-                    let uct = q + Self::CUCT * policy * expl;
+                    let cpuct = if root {
+                        Self::ROOT_CPUCT
+                    } else {
+                        Self::CPUCT
+                    };
+                    let uct = q + cpuct * policy * expl;
 
                     if uct > best_uct {
                         best_child_idx = child_idx;


### PR DESCRIPTION
```
Elo   | 56.68 +- 22.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.07 (-2.94, 2.94) [0.00, 10.00]
Games | N: 538 W: 201 L: 114 D: 223
Penta | [9, 50, 96, 73, 41]
```
https://mcthouacbb.pythonanywhere.com/test/756/

Bench: 19173934