### PR TITLE
Lower eval scale

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -140,7 +140,7 @@ pub struct MCTS {
 impl MCTS {
     const ROOT_CPUCT: f32 = 2.21858038;
     const CPUCT: f32 = std::f32::consts::SQRT_2;
-    const EVAL_SCALE: f32 = 200.0;
+    const EVAL_SCALE: f32 = 160.0;
 
     pub fn new(max_nodes: u32) -> Self {
         Self {


### PR DESCRIPTION
```
Elo   | 28.86 +- 15.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 10.00]
Games | N: 1110 W: 389 L: 297 D: 424
Penta | [40, 104, 196, 154, 61]
```
https://mcthouacbb.pythonanywhere.com/test/767/

Bench: 18219433