### PR TITLE
Penalize underpromos in policy

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -261,9 +261,8 @@ impl MCTS {
 
         let promo_bonus = if mv.kind() == MoveKind::Promotion {
             match mv.promo_piece() {
-                PieceType::Knight => 0.2,
                 PieceType::Queen => 2.0,
-                _ => 0.0,
+                _ => -3.0,
             }
         } else {
             0.0


### PR DESCRIPTION
Didn't pass yet but I'm merging anyways
```
Elo   | 2.33 +- 5.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.91 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 8044 W: 2450 L: 2396 D: 3198
Penta | [287, 920, 1564, 954, 297]
```
https://mcthouacbb.pythonanywhere.com/test/778/

Bench: 17432381