### PR TITLE
Tempo bonus

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -459,5 +459,5 @@ pub fn eval(board: &Board) -> i32 {
         + board.pieces(PieceType::Bishop).popcount()
         + board.pieces(PieceType::Knight).popcount()) as i32;
 
-    (eval.mg() * phase.min(24) + eval.eg() * (24 - phase.min(24))) / 24
+    (eval.mg() * phase.min(24) + eval.eg() * (24 - phase.min(24))) / 24 + 20
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -176,7 +176,7 @@ impl MCTS {
                         if root {
                             1000.0
                         } else {
-                            0.5
+                            node.q()
                         }
                     } else {
                         // 1 - child q because child q is from opposite perspective of current node


### PR DESCRIPTION
```
Elo   | 48.89 +- 21.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 608 W: 219 L: 134 D: 255
Penta | [12, 62, 95, 99, 36]
```
https://mcthouacbb.pythonanywhere.com/test/786/

Bench: 14318033