### PR TITLE
Fix PSQT policy

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -426,14 +426,14 @@ fn evaluate_pawns(board: &Board, color: Color) -> ScorePair {
     eval
 }
 
-pub fn psqt_score(board: &Board, pt: PieceType, sq: Square) -> i32 {
+pub fn psqt_score(board: &Board, pt: PieceType, sq: Square, c: Color) -> i32 {
     let phase = (4 * board.pieces(PieceType::Queen).popcount()
         + 2 * board.pieces(PieceType::Rook).popcount()
         + board.pieces(PieceType::Bishop).popcount()
         + board.pieces(PieceType::Knight).popcount()) as i32;
 
-    (PSQT[pt as usize][sq as usize].mg() as i32 * phase.min(24)
-        + PSQT[pt as usize][sq as usize].eg() as i32 * (24 - phase.min(24)))
+    (PSQT[pt as usize][sq.relative_sq(c).flip() as usize].mg() as i32 * phase.min(24)
+        + PSQT[pt as usize][sq.relative_sq(c).flip() as usize].eg() as i32 * (24 - phase.min(24)))
         / 24
 }
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -50,8 +50,8 @@ pub fn get_policy(board: &Board, mv: Move) -> f32 {
 
     let moving_piece = board.piece_at(mv.from_sq()).unwrap();
     let psqt = if mv.kind() != MoveKind::Promotion {
-        psqt_score(board, moving_piece.piece_type(), mv.to_sq())
-            - psqt_score(board, moving_piece.piece_type(), mv.from_sq())
+        psqt_score(board, moving_piece.piece_type(), mv.to_sq(), board.stm())
+            - psqt_score(board, moving_piece.piece_type(), mv.from_sq(), board.stm())
     } else {
         0
     };


### PR DESCRIPTION
Fix an issue with indexing PSQTs from the correct perspective in policy
```
Elo   | 16.14 +- 10.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 10.00]
Games | N: 2326 W: 769 L: 661 D: 896
Penta | [94, 242, 410, 296, 121]
```
https://mcthouacbb.pythonanywhere.com/test/798/

Bench: 13358376