### PR TITLE
Increase weight of PSQT policy

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -81,5 +81,5 @@ pub fn get_policy(board: &Board, mv: Move) -> f32 {
 
     cap_bonus + promo_bonus + pawn_threat_evasion + bad_see_penalty + check_bonus
         - pawn_protected_penalty
-        + psqt as f32 / 100.0
+        + psqt as f32 / 50.0
 }


### PR DESCRIPTION
```
Elo   | 13.84 +- 9.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 10.00]
Games | N: 2738 W: 889 L: 780 D: 1069
Penta | [95, 318, 478, 339, 139]
```
https://mcthouacbb.pythonanywhere.com/test/799/

Bench: 12829505