### PR TITLE
Increase eval scale and decrease cpuct

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -181,7 +181,7 @@ impl MCTS {
                     let policy = child.policy;
                     let expl = (node.visits as f32).sqrt() / (1 + child.visits) as f32;
                     let cpuct = if root { Self::ROOT_CPUCT } else { Self::CPUCT };
-                    let uct = q + cpuct * policy * expl;
+                    let uct = q + cpuct * policy * expl / 2.0;
 
                     if uct > best_uct {
                         best_child_idx = child_idx;

--- a/src/search.rs
+++ b/src/search.rs
@@ -134,8 +134,8 @@ pub struct MCTS {
 }
 
 impl MCTS {
-    const ROOT_CPUCT: f32 = 2.21858038;
-    const CPUCT: f32 = std::f32::consts::SQRT_2;
+    const ROOT_CPUCT: f32 = 1.10929019;
+    const CPUCT: f32 = 0.70710678;
     const EVAL_SCALE: f32 = 400.0;
 
     pub fn new(max_nodes: u32) -> Self {
@@ -181,7 +181,7 @@ impl MCTS {
                     let policy = child.policy;
                     let expl = (node.visits as f32).sqrt() / (1 + child.visits) as f32;
                     let cpuct = if root { Self::ROOT_CPUCT } else { Self::CPUCT };
-                    let uct = q + cpuct * policy * expl / 2.0;
+                    let uct = q + cpuct * policy * expl;
 
                     if uct > best_uct {
                         best_child_idx = child_idx;

--- a/src/search.rs
+++ b/src/search.rs
@@ -136,7 +136,7 @@ pub struct MCTS {
 impl MCTS {
     const ROOT_CPUCT: f32 = 2.21858038;
     const CPUCT: f32 = std::f32::consts::SQRT_2;
-    const EVAL_SCALE: f32 = 160.0;
+    const EVAL_SCALE: f32 = 400.0;
 
     pub fn new(max_nodes: u32) -> Self {
         Self {


### PR DESCRIPTION
```
Elo   | 18.28 +- 11.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 10.00]
Games | N: 1712 W: 467 L: 377 D: 868
Penta | [34, 198, 323, 246, 55]
```
https://mcthouacbb.pythonanywhere.com/test/802/

Bench: 13153165