### PR TITLE
Fix mobility

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -287,7 +287,7 @@ fn evaluate_piece(
 ) -> ScorePair {
     let mut eval = S(0, 0);
 
-    let opp_pawns = board.colored_pieces(Piece::new(!color, pt));
+    let opp_pawns = board.colored_pieces(Piece::new(!color, PieceType::Pawn));
     let mobility_area = !attacks::pawn_attacks_bb(!color, opp_pawns);
 
     let mut pieces = board.colored_pieces(Piece::new(color, pt));


### PR DESCRIPTION
```
Elo   | 26.81 +- 17.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 896 W: 303 L: 234 D: 359
Penta | [29, 95, 149, 128, 47]
```
https://mcthouacbb.pythonanywhere.com/test/826/

Bench: 13740574