### PR TITLE
Refactor MCTS

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -62,7 +62,7 @@ pub fn run_bench() {
     let start_time = Instant::now();
     let mut nodes = 0;
 
-    let mut searcher = MCTS::new(16777216);
+    let mut searcher = MCTS::new();
     let mut limits = SearchLimits::new();
     limits.max_depth = BENCH_DEPTH;
 

--- a/src/datagen.rs
+++ b/src/datagen.rs
@@ -10,7 +10,8 @@ use crate::{
         Move,
     },
     position::Position,
-    search::{GameResult, MateScore, Score, SearchLimits, MCTS},
+    search::{SearchLimits, MCTS},
+    tree::{GameResult, MateScore, Score},
     types::Color,
 };
 
@@ -60,7 +61,7 @@ pub fn run_datagen() {
 }
 
 pub fn datagen_thread(thread_id: i32) {
-    let mut search = MCTS::new(10000);
+    let mut search = MCTS::new();
     let seed = rand::rng().next_u64();
     println!("Thread {} RNG seed: {}", thread_id, seed);
 

--- a/src/datagen.rs
+++ b/src/datagen.rs
@@ -168,10 +168,9 @@ fn run_game(search: &mut MCTS, rng: &mut XorShiftRng) -> Game {
     loop {
         let results = search.run(limits, false, &pos);
         let mut datapt_score = match results.score {
-            Score::Mate(mate_score) => match mate_score {
-                MateScore::Loss(_) => 0.0,
-                MateScore::Win(_) => 1.0,
-            },
+            Score::Win(_) => 1.0,
+            Score::Draw => 0.5,
+            Score::Loss(_) => 0.0,
             Score::Normal(wdl) => wdl,
         };
         if pos.board().stm() == Color::Black {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod perft;
 mod policy;
 mod position;
 mod search;
+mod tree;
 mod tune;
 mod types;
 
@@ -90,7 +91,7 @@ fn main() {
     }
 
     let mut pos = Position::new();
-    let mut searcher = search::MCTS::new(1000000);
+    let mut searcher = search::MCTS::new();
     loop {
         let mut cmd = String::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn main() {
                 println!("bestmove {}", results.best_move);
             }
             Some("tree") => {
-                searcher.display_tree();
+                searcher.display_tree(1);
             }
             Some("quit") => {
                 return;

--- a/src/search.rs
+++ b/src/search.rs
@@ -271,17 +271,33 @@ impl MCTS {
         best_move
     }
 
-    pub fn display_tree(&self) {
-        let root_node = &self.tree[0];
-        for child_idx in root_node.child_indices() {
+    fn display_tree_impl(&self, node_idx: u32, depth: i32, ply: i32) {
+        if depth <= 0 {
+            return;
+        }
+        let indentation = || {
+            "    ".repeat(ply as usize)
+        };
+        let node = &self.tree[node_idx];
+        let mut children: Vec<u32> = node.child_indices().collect();
+        children.sort_by(|a, b| {
+            self.tree[*b].visits().cmp(&self.tree[*a].visits())
+        });
+        for child_idx in children {
             let child_node = &self.tree[child_idx];
             println!(
-                "{} => {} visits {}",
+                "{}{} => {} visits {}",
+                indentation(),
                 child_node.parent_move(),
                 child_node.visits(),
                 child_node.score()
             );
+            self.display_tree_impl(child_idx, depth - 1, ply + 1);
         }
+    }
+
+    pub fn display_tree(&self, depth: i32) {
+        self.display_tree_impl(self.tree.root_node(), depth, 0);
     }
 
     fn get_visit_dist(&self) -> Vec<(Move, f32)> {

--- a/src/search.rs
+++ b/src/search.rs
@@ -354,10 +354,6 @@ impl MCTS {
         while limits.max_nodes < 0 || self.iters <= limits.max_nodes as u32 {
             self.perform_one_iter();
 
-            // self.iters += 1;
-
-            // nodes += self.selection.len() as u64;
-
             let curr_depth = self.depth();
             if curr_depth > prev_depth {
                 if limits.max_depth > 0 && curr_depth >= limits.max_depth as u32 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -182,11 +182,14 @@ impl MCTS {
 
             self.nodes += ply + 1;
 
-            return (score, if game_result == GameResult::Mated {
-                Some(0)
-            } else {
-                None
-            });
+            return (
+                score,
+                if game_result == GameResult::Mated {
+                    Some(0)
+                } else {
+                    None
+                },
+            );
         } else {
             let mut best_uct = -1f32;
             let mut best_child_idx = 0u32;
@@ -213,13 +216,13 @@ impl MCTS {
                 }
             }
 
-            self.position.make_move(self.tree[best_child_idx].parent_move());
+            self.position
+                .make_move(self.tree[best_child_idx].parent_move());
             let (child_score, mut child_mate_dist) = self.perform_one_impl(best_child_idx, ply + 1);
-            
+
             if let Some(mate_dist) = child_mate_dist {
                 if mate_dist <= 0 {
-                    child_mate_dist =
-                        Self::try_prove_mate_win(&mut self.tree[node_idx], mate_dist);
+                    child_mate_dist = Self::try_prove_mate_win(&mut self.tree[node_idx], mate_dist);
                 } else {
                     child_mate_dist = Self::try_prove_mate_loss(&mut self.tree, node_idx);
                 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -275,14 +275,10 @@ impl MCTS {
         if depth <= 0 {
             return;
         }
-        let indentation = || {
-            "    ".repeat(ply as usize)
-        };
+        let indentation = || "    ".repeat(ply as usize);
         let node = &self.tree[node_idx];
         let mut children: Vec<u32> = node.child_indices().collect();
-        children.sort_by(|a, b| {
-            self.tree[*b].visits().cmp(&self.tree[*a].visits())
-        });
+        children.sort_by(|a, b| self.tree[*b].visits().cmp(&self.tree[*a].visits()));
         for child_idx in children {
             let child_node = &self.tree[child_idx];
             println!(

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,6 +1,4 @@
-use std::{mem::swap, num::NonZeroI16, ops::Range, time::Instant};
-
-use arrayvec::ArrayVec;
+use std::{num::NonZeroI16, time::Instant};
 
 use crate::{
     chess::{
@@ -8,83 +6,9 @@ use crate::{
         Board, Move,
     },
     eval,
-    policy::get_policy,
     position::Position,
+    tree::{GameResult, MateScore, Node, Score, Tree},
 };
-
-#[derive(PartialEq, Eq, Clone, Copy)]
-#[repr(u8)]
-pub enum GameResult {
-    NonTerminal,
-    Mated,
-    Drawn,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum MateScore {
-    Loss(u16),
-    Win(u16),
-}
-
-#[derive(Clone, Copy, PartialEq)]
-pub enum Score {
-    Mate(MateScore),
-    Normal(f32),
-}
-
-#[derive(Clone)]
-struct Node {
-    first_child_idx: u32,
-    child_count: u8,
-    parent_move: Move,
-    result: GameResult,
-    mate_dist: Option<NonZeroI16>,
-    policy: f32,
-    wins: f32,
-    visits: u32,
-}
-
-impl Node {
-    fn new(mv: Move, policy: f32) -> Self {
-        Node {
-            first_child_idx: 0,
-            child_count: 0,
-            parent_move: mv,
-            result: GameResult::NonTerminal,
-            mate_dist: None,
-            policy: policy,
-            wins: 0.0,
-            visits: 0,
-        }
-    }
-
-    fn q(&self) -> f32 {
-        self.wins / self.visits as f32
-    }
-
-    fn mate_score(&self) -> Option<MateScore> {
-        if self.result == GameResult::Mated {
-            Some(MateScore::Loss(0))
-        } else if let Some(mate_dist) = self.mate_dist {
-            let mate_dist = mate_dist.get() as i32;
-            if mate_dist > 0 {
-                Some(MateScore::Win(mate_dist as u16))
-            } else {
-                Some(MateScore::Loss(-mate_dist as u16))
-            }
-        } else {
-            None
-        }
-    }
-
-    fn is_terminal(&self) -> bool {
-        self.result != GameResult::NonTerminal
-    }
-
-    fn child_indices(&self) -> Range<u32> {
-        self.first_child_idx..(self.first_child_idx + self.child_count as u32)
-    }
-}
 
 fn sigmoid(x: f32, scale: f32) -> f32 {
     1.0 / (1.0 + (-x / scale).exp())
@@ -92,17 +16,6 @@ fn sigmoid(x: f32, scale: f32) -> f32 {
 
 fn sigmoid_inv(x: f32, scale: f32) -> f32 {
     scale * (x / (1.0 - x)).ln()
-}
-
-fn softmax(vals: &mut ArrayVec<f32, 256>, max_val: f32) {
-    let mut exp_sum = 0.0;
-    for v in vals.iter_mut() {
-        *v = (*v - max_val).exp();
-        exp_sum += *v;
-    }
-    for v in vals.iter_mut() {
-        *v /= exp_sum;
-    }
 }
 
 #[derive(Copy, Clone)]
@@ -137,8 +50,8 @@ impl SearchLimits {
 }
 
 pub struct MCTS {
-    nodes: Vec<Node>,
     iters: u32,
+    tree: Tree,
     root_position: Position,
     position: Position,
     selection: Vec<u32>,
@@ -149,9 +62,9 @@ impl MCTS {
     const CPUCT: f32 = 0.70710678;
     const EVAL_SCALE: f32 = 400.0;
 
-    pub fn new(max_nodes: u32) -> Self {
+    pub fn new() -> Self {
         Self {
-            nodes: Vec::with_capacity(max_nodes as usize),
+            tree: Tree::new(16),
             iters: 0,
             root_position: Position::new(),
             position: Position::new(),
@@ -165,21 +78,19 @@ impl MCTS {
         self.selection.push(node_idx);
 
         loop {
-            if self.nodes[node_idx as usize].child_count == 0
-                && self.nodes[node_idx as usize].visits == 1
-            {
-                self.expand_node(node_idx);
+            if self.tree[node_idx].child_count() == 0 && self.tree[node_idx].visits() == 1 {
+                self.tree.expand_node(node_idx, self.position.board());
             }
-            let node = &self.nodes[node_idx as usize];
+            let node = &self.tree[node_idx];
             let root = node_idx == 0;
-            if node.is_terminal() || node.child_count == 0 {
+            if node.is_terminal() || node.child_count() == 0 {
                 break;
             } else {
                 let mut best_uct = -1f32;
                 let mut best_child_idx = 0u32;
                 for child_idx in node.child_indices() {
-                    let child = &self.nodes[child_idx as usize];
-                    let q = if child.visits == 0 {
+                    let child = &self.tree[child_idx];
+                    let q = if child.visits() == 0 {
                         if root {
                             1000.0
                         } else {
@@ -189,8 +100,8 @@ impl MCTS {
                         // 1 - child q because child q is from opposite perspective of current node
                         1.0 - child.q()
                     };
-                    let policy = child.policy;
-                    let expl = (node.visits as f32).sqrt() / (1 + child.visits) as f32;
+                    let policy = child.policy();
+                    let expl = (node.visits() as f32).sqrt() / (1 + child.visits()) as f32;
                     let cpuct = if root { Self::ROOT_CPUCT } else { Self::CPUCT };
                     let uct = q + cpuct * policy * expl;
 
@@ -201,58 +112,15 @@ impl MCTS {
                 }
 
                 node_idx = best_child_idx;
-                let child = &self.nodes[best_child_idx as usize];
+                let child = &self.tree[best_child_idx];
                 // println!("{}, {}", self.position.board().to_fen(), child.parent_move);
-                self.position.make_move(child.parent_move);
+                self.position.make_move(child.parent_move());
                 self.selection.push(node_idx);
             }
         }
     }
 
-    fn expand_node(&mut self, node_idx: u32) {
-        let mut moves = MoveList::new();
-        movegen(self.position.board(), &mut moves);
-
-        let tmp = if node_idx == 0 { 3.0 } else { 1.0 };
-
-        let mut policies = ArrayVec::<f32, 256>::new();
-        let mut max_policy = 0f32;
-        for mv in moves.iter() {
-            let policy = get_policy(self.position.board(), *mv) / tmp;
-            max_policy = max_policy.max(policy);
-            policies.push(policy);
-        }
-
-        softmax(&mut policies, max_policy);
-
-        let first_child_idx = self.nodes.len() as u32;
-        let node = &mut self.nodes[node_idx as usize];
-        node.first_child_idx = first_child_idx;
-        node.child_count = moves.len() as u8;
-
-        for (i, mv) in moves.iter().enumerate() {
-            self.nodes.push(Node::new(*mv, policies[i]));
-        }
-    }
-
-    fn relabel_policies(&mut self, node_idx: u32, board: &Board) {
-        let mut policies = ArrayVec::<f32, 256>::new();
-        let mut max_policy = 0f32;
-
-        let tmp = if node_idx == 0 { 3.0 } else { 1.0 };
-
-        for child_idx in self.nodes[node_idx as usize].child_indices() {
-            let policy = get_policy(board, self.nodes[child_idx as usize].parent_move) / tmp;
-            max_policy = max_policy.max(policy);
-            policies.push(policy);
-        }
-
-        softmax(&mut policies, max_policy);
-
-        for (i, child_idx) in self.nodes[node_idx as usize].child_indices().enumerate() {
-            self.nodes[child_idx as usize].policy = policies[i];
-        }
-    }
+    fn expand_node(&mut self, node_idx: u32) {}
 
     fn eval_wdl(&self) -> f32 {
         let board = self.position.board();
@@ -290,12 +158,12 @@ impl MCTS {
         if let Some(mate_score) = node.mate_score() {
             match mate_score {
                 MateScore::Loss(_) => {
-                    node.mate_dist = Some(replace);
+                    node.set_mate_dist(Some(replace));
                     Some(move_mate_dist)
                 }
                 MateScore::Win(dist) => {
                     if move_mate_dist < dist as i32 {
-                        node.mate_dist = Some(replace);
+                        node.set_mate_dist(Some(replace));
                         Some(move_mate_dist)
                     } else {
                         None
@@ -303,17 +171,17 @@ impl MCTS {
                 }
             }
         } else {
-            node.mate_dist = Some(replace);
+            node.set_mate_dist(Some(replace));
             Some(move_mate_dist)
         }
     }
 
-    fn try_prove_mate_loss(nodes: &mut Vec<Node>, node_idx: u32) -> Option<i32> {
+    fn try_prove_mate_loss(tree: &mut Tree, node_idx: u32) -> Option<i32> {
         // a node is only proven to be a loss if every child is a win for the opponent
-        let node = &nodes[node_idx as usize];
+        let node = &tree[node_idx];
         let mut max_dist = 0;
         for child_idx in node.child_indices() {
-            let child_node = &nodes[child_idx as usize];
+            let child_node = &tree[child_idx];
             if let Some(mate_score) = child_node.mate_score() {
                 if let MateScore::Win(child_dist) = mate_score {
                     max_dist = max_dist.max(child_dist as i32);
@@ -324,7 +192,7 @@ impl MCTS {
                 return None;
             }
         }
-        let node = &mut nodes[node_idx as usize];
+        let node = &mut tree[node_idx];
         if max_dist > 0 {
             let move_dist = -max_dist - 1;
             let replace = NonZeroI16::new(move_dist as i16).unwrap();
@@ -332,7 +200,7 @@ impl MCTS {
                 match mate_score {
                     MateScore::Loss(mate_dist) => {
                         if -move_dist < mate_dist as i32 {
-                            node.mate_dist = Some(replace);
+                            node.set_mate_dist(Some(replace));
                             Some(move_dist)
                         } else {
                             None
@@ -343,7 +211,7 @@ impl MCTS {
                     }
                 }
             } else {
-                node.mate_dist = Some(replace);
+                node.set_mate_dist(Some(replace));
                 Some(move_dist as i32)
             }
         } else {
@@ -357,18 +225,17 @@ impl MCTS {
             if let Some(mate_dist) = child_mate_dist {
                 if mate_dist <= 0 {
                     child_mate_dist =
-                        Self::try_prove_mate_win(&mut self.nodes[*node_idx as usize], mate_dist);
+                        Self::try_prove_mate_win(&mut self.tree[*node_idx], mate_dist);
                 } else {
-                    child_mate_dist = Self::try_prove_mate_loss(&mut self.nodes, *node_idx as u32);
+                    child_mate_dist = Self::try_prove_mate_loss(&mut self.tree, *node_idx as u32);
                 }
             }
 
-            let node = &mut self.nodes[*node_idx as usize];
+            let node = &mut self.tree[*node_idx];
 
-            node.visits += 1;
-            node.wins += result;
+            node.add_score(result);
 
-            if node.result == GameResult::Mated {
+            if node.game_result() == GameResult::Mated {
                 child_mate_dist = Some(0);
             }
 
@@ -383,14 +250,14 @@ impl MCTS {
         let (score, game_result) = self.simulate();
 
         let leaf_idx = *self.selection.last().unwrap();
-        let leaf = &mut self.nodes[leaf_idx as usize];
-        leaf.result = game_result;
+        let leaf = &mut self.tree[leaf_idx];
+        leaf.set_game_result(game_result);
 
         self.backprop(score);
     }
 
     fn root_move_score(child_node: &Node) -> f32 {
-        match child_node.result {
+        match child_node.game_result() {
             GameResult::NonTerminal => {
                 if let Some(mate_score) = child_node.mate_score() {
                     match mate_score {
@@ -407,27 +274,27 @@ impl MCTS {
     }
 
     fn get_best_move(&self) -> Move {
-        let root_node = &self.nodes[0];
+        let root_node = &self.tree[0];
         let mut best_score = -1000.0;
         let mut best_move = Move::NULL;
         for child_idx in root_node.child_indices() {
-            let child_node = &self.nodes[child_idx as usize];
-            if child_node.visits == 0 {
+            let child_node = &self.tree[child_idx];
+            if child_node.visits() == 0 {
                 continue;
             }
             let score = Self::root_move_score(child_node);
             if score > best_score {
                 best_score = score;
-                best_move = child_node.parent_move;
+                best_move = child_node.parent_move();
             }
         }
         best_move
     }
 
     pub fn display_tree(&self) {
-        let root_node = &self.nodes[0];
+        let root_node = &self.tree[0];
         for child_idx in root_node.child_indices() {
-            let child_node = &self.nodes[child_idx as usize];
+            let child_node = &self.tree[child_idx];
             let score_str = if let Some(mate_score) = child_node.mate_score() {
                 // child win = parent loss and vice versa
                 match mate_score {
@@ -439,19 +306,21 @@ impl MCTS {
             };
             println!(
                 "{} => {} visits {}",
-                child_node.parent_move, child_node.visits, score_str
+                child_node.parent_move(),
+                child_node.visits(),
+                score_str
             );
         }
     }
 
     fn get_visit_dist(&self) -> Vec<(Move, f32)> {
         let mut result = Vec::new();
-        let total = self.nodes[0].visits;
-        for child_idx in self.nodes[0].child_indices() {
-            let child_node = &self.nodes[child_idx as usize];
+        let total = self.tree[self.tree.root_node()].visits();
+        for child_idx in self.tree[0].child_indices() {
+            let child_node = &self.tree[child_idx];
             result.push((
-                child_node.parent_move,
-                child_node.visits as f32 / total as f32,
+                child_node.parent_move(),
+                child_node.visits() as f32 / total as f32,
             ));
         }
         result
@@ -459,60 +328,24 @@ impl MCTS {
 
     // depth 2 perft to find the node
     fn find_node(&self, position: &Position) -> Option<u32> {
-        if self.nodes.len() == 0 {
+        if self.tree.size() == 0 {
             return None;
         }
-        let root_node = &self.nodes[0];
+        let root_node = &self.tree[0];
         for child_idx in root_node.child_indices() {
-            let child_node = &self.nodes[child_idx as usize];
+            let child_node = &self.tree[child_idx];
             let mut new_pos = self.root_position.clone();
-            new_pos.make_move(child_node.parent_move);
+            new_pos.make_move(child_node.parent_move());
             for child2_idx in child_node.child_indices() {
-                let child2_node = &self.nodes[child2_idx as usize];
+                let child2_node = &self.tree[child2_idx];
                 let mut new_pos2 = new_pos.clone();
-                new_pos2.make_move(child2_node.parent_move);
+                new_pos2.make_move(child2_node.parent_move());
                 if new_pos2 == *position {
-                    println!("{} {}", child_node.parent_move, child2_node.parent_move);
                     return Some(child2_idx);
                 }
             }
         }
         None
-    }
-
-    fn build_tree(&mut self, old_nodes: &Vec<Node>, node_idx: u32) {
-        let old_node = &old_nodes[node_idx as usize];
-        self.nodes.push(old_node.clone());
-
-        self.build_tree_impl(old_nodes, node_idx, 0);
-    }
-
-    fn build_tree_impl(&mut self, old_nodes: &Vec<Node>, old_node_idx: u32, new_node_idx: u32) {
-        let old_node = &old_nodes[old_node_idx as usize];
-        let first_child_idx = self.nodes.len() as u32;
-        if old_node.child_count == 0 {
-            return;
-        }
-
-        {
-            let new_node: &mut Node = &mut self.nodes[new_node_idx as usize];
-            new_node.child_count = old_node.child_count;
-            new_node.first_child_idx = first_child_idx as u32;
-        }
-
-        for old_child_idx in old_node.child_indices() {
-            let old_child = &old_nodes[old_child_idx as usize];
-            self.nodes.push(old_child.clone());
-        }
-
-        for (iter, old_child_idx) in old_node.child_indices().enumerate() {
-            let new_node = &self.nodes[new_node_idx as usize];
-            self.build_tree_impl(
-                old_nodes,
-                old_child_idx,
-                new_node.first_child_idx + iter as u32,
-            );
-        }
     }
 
     pub fn run(
@@ -528,16 +361,17 @@ impl MCTS {
         self.iters = 0;
 
         if let Some(old_node_idx) = node_idx {
-            let mut old_nodes = Vec::with_capacity(self.nodes.capacity());
-            swap(&mut old_nodes, &mut self.nodes);
-            self.build_tree(&old_nodes, old_node_idx);
-            self.relabel_policies(0, &self.root_position.board().clone());
+            self.tree = Tree::rebuild(&self.tree, old_node_idx);
+            self.tree
+                .relabel_policies(self.tree.root_node(), &self.root_position.board().clone());
         } else {
-            self.nodes.clear();
-            self.nodes.push(Node::new(Move::NULL, 0.0));
-            self.expand_node(0);
-            self.nodes[0].visits += 1;
-            self.nodes[0].wins += self.eval_wdl();
+            self.tree.clear();
+            self.tree.add_root_node();
+            self.tree
+                .expand_node(self.tree.root_node(), self.root_position.board());
+            let eval = self.eval_wdl();
+            let root = self.tree.root_node();
+            self.tree[root].add_score(eval);
         }
 
         let mut total_depth = 0;
@@ -563,17 +397,19 @@ impl MCTS {
                 prev_depth = curr_depth;
                 if report {
                     let elapsed = start_time.elapsed().as_secs_f64();
-                    let score_str = if let Some(mate_score) = self.nodes[0].mate_score() {
-                        match mate_score {
-                            MateScore::Loss(dist) => format!("mate {}", -(dist as i32) / 2),
-                            MateScore::Win(dist) => format!("mate {}", (dist as i32 + 1) / 2),
-                        }
-                    } else {
-                        format!(
-                            "cp {}",
-                            sigmoid_inv(self.nodes[0].q(), Self::EVAL_SCALE).round()
-                        )
-                    };
+                    let score_str =
+                        if let Some(mate_score) = self.tree[self.tree.root_node()].mate_score() {
+                            match mate_score {
+                                MateScore::Loss(dist) => format!("mate {}", -(dist as i32) / 2),
+                                MateScore::Win(dist) => format!("mate {}", (dist as i32 + 1) / 2),
+                            }
+                        } else {
+                            format!(
+                                "cp {}",
+                                sigmoid_inv(self.tree[self.tree.root_node()].q(), Self::EVAL_SCALE)
+                                    .round()
+                            )
+                        };
                     println!(
                         "info depth {} nodes {} time {} nps {} score {} pv {}",
                         curr_depth,
@@ -603,7 +439,7 @@ impl MCTS {
         if report {
             let curr_depth = total_depth / self.iters;
             let elapsed = start_time.elapsed().as_secs_f64();
-            let score_str = if let Some(mate_score) = self.nodes[0].mate_score() {
+            let score_str = if let Some(mate_score) = self.tree[0].mate_score() {
                 match mate_score {
                     MateScore::Loss(dist) => format!("mate {}", -(dist as i32) / 2),
                     MateScore::Win(dist) => format!("mate {}", (dist as i32 + 1) / 2),
@@ -611,7 +447,7 @@ impl MCTS {
             } else {
                 format!(
                     "cp {}",
-                    sigmoid_inv(self.nodes[0].q(), Self::EVAL_SCALE).round()
+                    sigmoid_inv(self.tree[0].q(), Self::EVAL_SCALE).round()
                 )
             };
             println!(
@@ -628,16 +464,16 @@ impl MCTS {
         SearchResults {
             best_move: self.get_best_move(),
             nodes: nodes,
-            score: if let Some(mate_score) = self.nodes[0].mate_score() {
+            score: if let Some(mate_score) = self.tree[0].mate_score() {
                 Score::Mate(mate_score)
             } else {
-                Score::Normal(self.nodes[0].q())
+                Score::Normal(self.tree[0].q())
             },
             visit_dist: self.get_visit_dist(),
         }
     }
 
     pub fn new_game(&mut self) {
-        self.nodes.clear();
+        self.tree.clear();
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,7 @@ use std::{num::NonZeroI16, time::Instant};
 use crate::{
     chess::{
         movegen::{movegen, MoveList},
-        Board, Move,
+        Move,
     },
     eval,
     position::Position,
@@ -119,8 +119,6 @@ impl MCTS {
             }
         }
     }
-
-    fn expand_node(&mut self, node_idx: u32) {}
 
     fn eval_wdl(&self) -> f32 {
         let board = self.position.board();

--- a/src/search.rs
+++ b/src/search.rs
@@ -62,7 +62,7 @@ impl MCTS {
 
     pub fn new() -> Self {
         Self {
-            tree: Tree::new(16),
+            tree: Tree::new(24),
             iters: 0,
             root_position: Position::new(),
             position: Position::new(),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -46,7 +46,7 @@ impl Score {
             Self::Win(dist) => Self::Loss(*dist),
             Self::Draw => Self::Draw,
             Self::Loss(dist) => Self::Win(*dist),
-            Self::Normal(score) => Self::Normal(-score),
+            Self::Normal(score) => Self::Normal(1.0 - score),
         }
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,265 @@
+use std::{
+    num::NonZeroI16,
+    ops::{Index, IndexMut, Range},
+};
+
+use arrayvec::ArrayVec;
+
+use crate::{
+    chess::{
+        movegen::{self, MoveList},
+        Board, Move,
+    },
+    policy,
+};
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
+pub enum GameResult {
+    NonTerminal,
+    Mated,
+    Drawn,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum MateScore {
+    Loss(u16),
+    Win(u16),
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum Score {
+    Mate(MateScore),
+    Normal(f32),
+}
+
+#[derive(Clone)]
+pub struct Node {
+    first_child_idx: u32,
+    child_count: u8,
+    parent_move: Move,
+    result: GameResult,
+    mate_dist: Option<NonZeroI16>,
+    policy: f32,
+    wins: f32,
+    visits: u32,
+}
+
+impl Node {
+    fn new(mv: Move, policy: f32) -> Self {
+        Node {
+            first_child_idx: 0,
+            child_count: 0,
+            parent_move: mv,
+            result: GameResult::NonTerminal,
+            mate_dist: None,
+            policy: policy,
+            wins: 0.0,
+            visits: 0,
+        }
+    }
+
+    pub fn q(&self) -> f32 {
+        self.wins / self.visits as f32
+    }
+
+    pub fn mate_score(&self) -> Option<MateScore> {
+        if self.result == GameResult::Mated {
+            Some(MateScore::Loss(0))
+        } else if let Some(mate_dist) = self.mate_dist {
+            let mate_dist = mate_dist.get() as i32;
+            if mate_dist > 0 {
+                Some(MateScore::Win(mate_dist as u16))
+            } else {
+                Some(MateScore::Loss(-mate_dist as u16))
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.result != GameResult::NonTerminal
+    }
+
+    pub fn child_count(&self) -> u32 {
+        self.child_count as u32
+    }
+
+    pub fn game_result(&self) -> GameResult {
+        self.result
+    }
+
+    pub fn child_indices(&self) -> Range<u32> {
+        self.first_child_idx..(self.first_child_idx + self.child_count as u32)
+    }
+
+    pub fn visits(&self) -> u32 {
+        self.visits
+    }
+
+    pub fn parent_move(&self) -> Move {
+        self.parent_move
+    }
+
+    pub fn policy(&self) -> f32 {
+        self.policy
+    }
+
+    pub fn add_score(&mut self, score: f32) {
+        self.visits += 1;
+        self.wins += score;
+    }
+
+    pub fn set_mate_dist(&mut self, mate_dist: Option<NonZeroI16>) {
+        self.mate_dist = mate_dist;
+    }
+
+    pub fn set_game_result(&mut self, result: GameResult) {
+        self.result = result;
+    }
+}
+
+fn softmax(vals: &mut ArrayVec<f32, 256>, max_val: f32) {
+    let mut exp_sum = 0.0;
+    for v in vals.iter_mut() {
+        *v = (*v - max_val).exp();
+        exp_sum += *v;
+    }
+    for v in vals.iter_mut() {
+        *v /= exp_sum;
+    }
+}
+
+pub struct Tree {
+    nodes: Vec<Node>,
+}
+
+impl Tree {
+    pub fn new(mb: usize) -> Self {
+        let nodes = mb * 1024 * 1024 / std::mem::size_of::<Tree>();
+        Self {
+            nodes: Vec::with_capacity(nodes),
+        }
+    }
+
+    fn build_tree_impl(&mut self, old_tree: &Tree, old_node_idx: u32, new_node_idx: u32) {
+        let old_node = &old_tree[old_node_idx];
+        let first_child_idx = self.nodes.len() as u32;
+        if old_node.child_count == 0 {
+            return;
+        }
+
+        {
+            let new_node: &mut Node = &mut self[new_node_idx];
+            new_node.child_count = old_node.child_count;
+            new_node.first_child_idx = first_child_idx as u32;
+        }
+
+        for old_child_idx in old_node.child_indices() {
+            let old_child = &old_tree[old_child_idx];
+            self.nodes.push(old_child.clone());
+        }
+
+        for (iter, old_child_idx) in old_node.child_indices().enumerate() {
+            let new_node = &self[new_node_idx];
+            self.build_tree_impl(
+                old_tree,
+                old_child_idx,
+                new_node.first_child_idx + iter as u32,
+            );
+        }
+    }
+
+    pub fn rebuild(old_tree: &Tree, node_idx: u32) -> Self {
+        let mut new_tree = Self {
+            nodes: Vec::with_capacity(old_tree.nodes.capacity()),
+        };
+
+        new_tree.nodes.push(old_tree[node_idx].clone());
+        new_tree.build_tree_impl(old_tree, node_idx, 0);
+
+        new_tree
+    }
+
+    pub fn add_root_node(&mut self) {
+        assert!(self.nodes.len() == 0);
+        self.nodes.push(Node::new(Move::NULL, 0.0));
+    }
+
+    pub fn expand_node(&mut self, node_idx: u32, board: &Board) {
+        let mut moves = MoveList::new();
+        movegen::movegen(board, &mut moves);
+
+        // overflow check for later when implementing LRU
+        // if self.nodes.len() + moves.len() > self.nodes.capacity() {
+        //     return None
+        // }
+
+        let tmp = if node_idx == 0 { 3.0 } else { 1.0 };
+
+        let mut policies = ArrayVec::<f32, 256>::new();
+        let mut max_policy = 0f32;
+        for mv in moves.iter() {
+            let policy = policy::get_policy(board, *mv) / tmp;
+            max_policy = max_policy.max(policy);
+            policies.push(policy);
+        }
+
+        softmax(&mut policies, max_policy);
+
+        let first_child_idx = self.nodes.len() as u32;
+        let node = &mut self.nodes[node_idx as usize];
+        node.first_child_idx = first_child_idx;
+        node.child_count = moves.len() as u8;
+
+        for (i, mv) in moves.iter().enumerate() {
+            self.nodes.push(Node::new(*mv, policies[i]));
+        }
+    }
+
+    pub fn relabel_policies(&mut self, node_idx: u32, board: &Board) {
+        let mut policies = ArrayVec::<f32, 256>::new();
+        let mut max_policy = 0f32;
+
+        let tmp = if node_idx == 0 { 3.0 } else { 1.0 };
+
+        for child_idx in self.nodes[node_idx as usize].child_indices() {
+            let policy =
+                policy::get_policy(board, self.nodes[child_idx as usize].parent_move) / tmp;
+            max_policy = max_policy.max(policy);
+            policies.push(policy);
+        }
+
+        softmax(&mut policies, max_policy);
+
+        for (i, child_idx) in self.nodes[node_idx as usize].child_indices().enumerate() {
+            self.nodes[child_idx as usize].policy = policies[i];
+        }
+    }
+
+    pub fn size(&self) -> u32 {
+        self.nodes.len() as u32
+    }
+
+    pub fn root_node(&self) -> u32 {
+        0
+    }
+
+    pub fn clear(&mut self) {
+        self.nodes.clear();
+    }
+}
+
+impl Index<u32> for Tree {
+    type Output = Node;
+    fn index(&self, index: u32) -> &Self::Output {
+        &self.nodes[index as usize]
+    }
+}
+
+impl IndexMut<u32> for Tree {
+    fn index_mut(&mut self, index: u32) -> &mut Self::Output {
+        &mut self.nodes[index as usize]
+    }
+}

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -57,7 +57,7 @@ impl fmt::Display for Score {
             Self::Win(dist) => write!(f, "win {} plies", *dist),
             Self::Draw => write!(f, "draw"),
             Self::Loss(dist) => write!(f, "loss {} plies", *dist),
-            Self::Normal(score) => write!(f, "{} cp", sigmoid_inv(*score, 400.0).round()),
+            Self::Normal(score) => write!(f, "cp {}", sigmoid_inv(*score, 400.0).round()),
         }
     }
 }


### PR DESCRIPTION
- Refactor the tree into its own type
- Use recursive instead of iterative formulation of MCTS
- Refactor some other parts of search

Seems to lose a bit of speed but it's small enough that idc
```
Elo   | -6.02 +- 6.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.65 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 5136 W: 1305 L: 1394 D: 2437
Penta | [164, 599, 1100, 572, 133]
```
https://mcthouacbb.pythonanywhere.com/test/882/

Search is functionally the same. Every pair is drawn at fixed nodes
```
Elo   | -0.00 +- 0.00 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 3576 W: 1087 L: 1087 D: 1402
Penta | [0, 0, 1788, 0, 0]
```
https://mcthouacbb.pythonanywhere.com/test/879/

Bench: 13031029