### PR TITLE
Tree Halves LRU

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -365,6 +365,7 @@ impl MCTS {
 
         if let Some(new_root_idx) = node_idx {
             self.tree.set_as_root(new_root_idx);
+            self.tree.relabel_policies(self.tree.root_node(), &self.root_position.board());
         } else {
             self.tree.clear();
             self.tree

--- a/src/search.rs
+++ b/src/search.rs
@@ -348,7 +348,7 @@ impl MCTS {
     }
 
     fn depth(&self) -> u32 {
-        (self.nodes - self.iters) / self.iters
+        (self.nodes - self.iters) / self.iters.max(1)
     }
 
     pub fn run(
@@ -386,6 +386,7 @@ impl MCTS {
             let result = self.perform_one_iter();
             if result.is_err() {
                 self.tree.flip();
+                continue;
             }
 
             let curr_depth = self.depth();
@@ -393,6 +394,7 @@ impl MCTS {
                 if limits.max_depth > 0 && curr_depth >= limits.max_depth as u32 {
                     break;
                 }
+
                 prev_depth = curr_depth;
                 if report {
                     let elapsed = start_time.elapsed().as_secs_f64();

--- a/src/search.rs
+++ b/src/search.rs
@@ -362,11 +362,11 @@ impl MCTS {
         self.iters = 0;
         self.nodes = 0;
 
-        if let Some(old_node_idx) = node_idx {
-            self.tree = Tree::rebuild(&self.tree, old_node_idx);
-            self.tree
-                .relabel_policies(self.tree.root_node(), &self.root_position.board().clone());
-        } else {
+        // if let Some(old_node_idx) = node_idx {
+            // self.tree = Tree::rebuild(&self.tree, old_node_idx);
+            // self.tree
+                // .relabel_policies(self.tree.root_node(), &self.root_position.board().clone());
+        // } else {
             self.tree.clear();
             self.tree.add_root_node();
             self.tree
@@ -374,7 +374,7 @@ impl MCTS {
             let eval = self.eval_wdl();
             let root = self.tree.root_node();
             self.tree[root].add_score(eval);
-        }
+        // }
 
         let mut prev_depth = 0;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -363,19 +363,16 @@ impl MCTS {
         self.iters = 0;
         self.nodes = 0;
 
-        // for tree reuse later
-        // if let Some(old_node_idx) = node_idx {
-            // self.tree = Tree::rebuild(&self.tree, old_node_idx);
-            // self.tree
-                // .relabel_policies(self.tree.root_node(), &self.root_position.board().clone());
-        // } else {
-        self.tree.clear();
-        self.tree
-            .expand_node(self.tree.root_node(), self.root_position.board()).expect("Cannot expand root node in tree");
-        let eval = self.eval_wdl();
-        let root = self.tree.root_node();
-        self.tree[root].add_score(eval);
-        // }
+        if let Some(new_root_idx) = node_idx {
+            self.tree.set_as_root(new_root_idx);
+        } else {
+            self.tree.clear();
+            self.tree
+                .expand_node(self.tree.root_node(), self.root_position.board()).expect("Cannot expand root node in tree");
+            let eval = self.eval_wdl();
+            let root = self.tree.root_node();
+            self.tree[root].add_score(eval);
+        }
 
         let mut prev_depth = 0;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -370,6 +370,7 @@ impl MCTS {
                 .relabel_policies(self.tree.root_node(), &self.root_position.board());
         } else {
             self.tree.clear();
+            self.tree.add_root_node();
             self.tree
                 .expand_node(self.tree.root_node(), self.root_position.board())
                 .expect("Cannot expand root node in tree");

--- a/src/search.rs
+++ b/src/search.rs
@@ -176,11 +176,8 @@ impl MCTS {
     }
 
     fn perform_one_impl(&mut self, node_idx: NodeIndex, ply: u32) -> Option<(f32, Option<i32>)> {
-        if self.tree[node_idx].child_count() == 0 && self.tree[node_idx].visits() == 1 {
-            self.tree.expand_node(node_idx, self.position.board())?;
-        }
         let root = node_idx == self.tree.root_node();
-        if self.tree[node_idx].is_terminal() || self.tree[node_idx].child_count() == 0 {
+        if self.tree[node_idx].is_terminal() || self.tree[node_idx].visits() == 0 {
             let (score, game_result) = self.simulate();
 
             let node = &mut self.tree[node_idx];
@@ -198,7 +195,12 @@ impl MCTS {
                 },
             ));
         } else {
+            // node can't be terminal here, must be unexpanded
+            if self.tree[node_idx].child_count() == 0 {
+                self.tree.expand_node(node_idx, self.position.board())?;
+            }
             self.tree.fetch_children(node_idx);
+
             let node = &self.tree[node_idx];
 
             let mut best_uct = -1f32;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -185,45 +185,6 @@ impl Tree {
         }
     }
 
-    fn build_tree_impl(&mut self, old_tree: &Tree, old_node_idx: u32, new_node_idx: u32) {
-        let old_node = &old_tree[old_node_idx];
-        let first_child_idx = self.nodes.len() as u32;
-        if old_node.child_count == 0 {
-            return;
-        }
-
-        {
-            let new_node: &mut Node = &mut self[new_node_idx];
-            new_node.child_count = old_node.child_count;
-            new_node.first_child_idx = first_child_idx as u32;
-        }
-
-        for old_child_idx in old_node.child_indices() {
-            let old_child = &old_tree[old_child_idx];
-            self.nodes.push(old_child.clone());
-        }
-
-        for (iter, old_child_idx) in old_node.child_indices().enumerate() {
-            let new_node = &self[new_node_idx];
-            self.build_tree_impl(
-                old_tree,
-                old_child_idx,
-                new_node.first_child_idx + iter as u32,
-            );
-        }
-    }
-
-    pub fn rebuild(old_tree: &Tree, node_idx: u32) -> Self {
-        let mut new_tree = Self {
-            nodes: Vec::with_capacity(old_tree.nodes.capacity()),
-        };
-
-        new_tree.nodes.push(old_tree[node_idx].clone());
-        new_tree.build_tree_impl(old_tree, node_idx, 0);
-
-        new_tree
-    }
-
     pub fn add_root_node(&mut self) {
         assert!(self.nodes.len() == 0);
         self.nodes.push(Node::new(Move::NULL, 0.0));

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -321,9 +321,8 @@ impl Tree {
     }
 
     pub fn set_as_root(&mut self, node_idx: NodeIndex) {
-        assert!(node_idx.half() == self.active_half);
         let root = self.root_node();
-        self[root] = self[node_idx].clone();
+        self.copy_node_across(node_idx, root);
     }
 
     pub fn fetch_children(&mut self, node_idx: NodeIndex) -> Option<()> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -275,6 +275,10 @@ impl Half {
             }
         }
     }
+
+    fn clear(&mut self) {
+        self.used = 0;
+    }
 }
 
 pub struct Tree {
@@ -307,12 +311,13 @@ impl Tree {
     }
 
     pub fn clear(&mut self) {
-        self.curr_half_mut().used = 1;
-        self.reset_root_node();
+        self.halves[0].clear();
+        self.halves[1].clear();
     }
 
-    pub fn reset_root_node(&mut self) {
-        let root = self.root_node();
+    pub fn add_root_node(&mut self) {
+        let root = self.alloc_nodes(1).unwrap();
+        assert!(root == self.root_node());
         self[root] = Node::new(Move::NULL, 0.0);
     }
 
@@ -322,8 +327,9 @@ impl Tree {
         self.curr_half_mut().clear_indices(half);
 
         self.active_half ^= 1;
-        let new_root = self.root_node();
-        self.curr_half_mut().used = 1;
+        self.curr_half_mut().clear();
+        let new_root = self.alloc_nodes(1).unwrap();
+        assert!(new_root == self.root_node());
         self.copy_node_across(old_root, new_root);
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -329,7 +329,6 @@ impl Tree {
 
     pub fn set_as_root(&mut self, node_idx: NodeIndex) {
         let root = self.root_node();
-        println!("info string root {} curr half {} children ({}, {}) child index {} parent move {} game result {} wins {} visits", self.active_half, self[node_idx].child_count, self[node_idx].first_child_idx.half(), self[node_idx].first_child_idx.index(), self[node_idx].parent_move, self[node_idx].game_result() as i32, self[node_idx].wins, self[node_idx].visits);
         self.copy_node_across(node_idx, root);
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -229,14 +229,13 @@ impl Tree {
         self.nodes.push(Node::new(Move::NULL, 0.0));
     }
 
-    pub fn expand_node(&mut self, node_idx: u32, board: &Board) {
+    pub fn expand_node(&mut self, node_idx: u32, board: &Board) -> Result<(), ()> {
         let mut moves = MoveList::new();
         movegen::movegen(board, &mut moves);
 
-        // overflow check for later when implementing LRU
-        // if self.nodes.len() + moves.len() > self.nodes.capacity() {
-        //     return None
-        // }
+        if self.nodes.len() + moves.len() > self.nodes.capacity() {
+            return Err(())
+        }
 
         let tmp = if node_idx == 0 { 3.0 } else { 1.0 };
 
@@ -258,6 +257,8 @@ impl Tree {
         for (i, mv) in moves.iter().enumerate() {
             self.nodes.push(Node::new(*mv, policies[i]));
         }
+
+        return Ok(())
     }
 
     pub fn relabel_policies(&mut self, node_idx: u32, board: &Board) {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -375,7 +375,7 @@ impl Tree {
         let mut policies = ArrayVec::<f32, 256>::new();
         let mut max_policy = 0f32;
 
-        let tmp = if node_idx.index() == 0 { 3.0 } else { 1.0 };
+        let tmp = if node_idx == self.root_node() { 3.0 } else { 1.0 };
 
         for child_idx in self[node_idx].child_indices() {
             let policy =

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -320,6 +320,12 @@ impl Tree {
         self.copy_node_across(old_root, new_root);
     }
 
+    pub fn set_as_root(&mut self, node_idx: NodeIndex) {
+        assert!(node_idx.half() == self.active_half);
+        let root = self.root_node();
+        self[root] = self[node_idx].clone();
+    }
+
     pub fn fetch_children(&mut self, node_idx: NodeIndex) -> Option<()> {
         let old_first_child_idx = self[node_idx].first_child_idx;
 


### PR DESCRIPTION
LRU vs baseline
```
Elo   | 140.40 +- 36.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 3.11 (-2.94, 2.94) [0.00, 10.00]
Games | N: 266 W: 145 L: 43 D: 78
Penta | [2, 11, 40, 43, 37]
```
https://mcthouacbb.pythonanywhere.com/test/899/

LRU + tree reuse vs LRU
```
Elo   | 62.43 +- 23.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 10.00]
Games | N: 450 W: 176 L: 96 D: 178
Penta | [5, 37, 87, 65, 31]
```
https://mcthouacbb.pythonanywhere.com/test/902/

LRU + tree reuse vs LRU with large hash
```
Elo   | 115.68 +- 30.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 274 W: 121 L: 33 D: 120
Penta | [1, 13, 46, 51, 26]
```
https://mcthouacbb.pythonanywhere.com/test/904/

LRU + tree reuse vs main with large hash
```
Elo   | 7.96 +- 14.71 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=64MB
Games | N: 1004 W: 262 L: 239 D: 503
Penta | [22, 127, 188, 136, 29]
https://mcthouacbb.pythonanywhere.com/test/907/
```

Bench: 14009209