### PR TITLE
Score two-fold repetitions in search as a draw

### DIFF
--- a/src/chess/board.rs
+++ b/src/chess/board.rs
@@ -424,11 +424,12 @@ impl Board {
             | (attacks::rook_attacks(sq, occ) & hvs)
     }
 
-    pub fn is_drawn(&self, keys: &Vec<ZobristKey>) -> bool {
+    pub fn is_drawn(&self, keys: &Vec<ZobristKey>, ply: i32) -> bool {
         if self.half_move_clock >= 100 {
             return true;
         }
         let mut count = 1;
+        let mut ply_dist = 4;
         for &hash in keys
             .iter()
             .rev()
@@ -438,10 +439,11 @@ impl Board {
         {
             if hash == self.zkey() {
                 count += 1;
-                if count == 3 {
+                if count == 3 || (count == 2 && ply_dist <= ply) {
                     return true;
                 }
             }
+            ply_dist += 2;
         }
         return false;
     }

--- a/src/datagen.rs
+++ b/src/datagen.rs
@@ -133,7 +133,7 @@ fn game_result(pos: &Position) -> GameResult {
         } else {
             GameResult::Drawn
         }
-    } else if pos.is_drawn() {
+    } else if pos.is_drawn(0) {
         GameResult::Drawn
     } else {
         GameResult::NonTerminal

--- a/src/position.rs
+++ b/src/position.rs
@@ -35,7 +35,7 @@ impl Position {
         self.board.make_move(mv);
     }
 
-    pub fn is_drawn(&self) -> bool {
-        self.board.is_drawn(&self.keys)
+    pub fn is_drawn(&self, depth: i32) -> bool {
+        self.board.is_drawn(&self.keys, depth)
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -83,7 +83,7 @@ impl MCTS {
         sigmoid(eval as f32, Self::EVAL_SCALE)
     }
 
-    fn simulate(&self) -> (f32, GameResult) {
+    fn simulate(&self, ply: i32) -> (f32, GameResult) {
         let mut moves = MoveList::new();
         movegen(self.position.board(), &mut moves);
 
@@ -93,7 +93,7 @@ impl MCTS {
             } else {
                 GameResult::Drawn
             }
-        } else if self.position.is_drawn() {
+        } else if self.position.is_drawn(ply) {
             GameResult::Drawn
         } else {
             GameResult::NonTerminal
@@ -176,7 +176,7 @@ impl MCTS {
     fn perform_one_impl(&mut self, node_idx: NodeIndex, ply: u32) -> Option<(f32, Option<i32>)> {
         let root = node_idx == self.tree.root_node();
         if self.tree[node_idx].is_terminal() || self.tree[node_idx].visits() == 0 {
-            let (score, game_result) = self.simulate();
+            let (score, game_result) = self.simulate(ply as i32);
 
             let node = &mut self.tree[node_idx];
             node.set_game_result(game_result);


### PR DESCRIPTION
```
Elo   | 17.53 +- 10.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.07 (-2.94, 2.94) [0.00, 10.00]
Games | N: 1726 W: 427 L: 340 D: 959
Penta | [32, 189, 352, 240, 50]
```
https://mcthouacbb.pythonanywhere.com/test/946/

Bench: 10631736