### PR TITLE
Fix eval scale

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -54,8 +54,8 @@ pub struct MCTS {
 }
 
 impl MCTS {
-    const ROOT_CPUCT: f32 = 1.7 * 1.10929019;
-    const CPUCT: f32 = 1.7 * 0.70710678;
+    const ROOT_CPUCT: f32 = 1.9 * 1.10929019;
+    const CPUCT: f32 = 1.9 * 0.70710678;
     pub const EVAL_SCALE: f32 = 187.5;
 
     pub fn new() -> Self {

--- a/src/search.rs
+++ b/src/search.rs
@@ -54,9 +54,9 @@ pub struct MCTS {
 }
 
 impl MCTS {
-    const ROOT_CPUCT: f32 = 1.10929019;
-    const CPUCT: f32 = 0.70710678;
-    const EVAL_SCALE: f32 = 400.0;
+    const ROOT_CPUCT: f32 = 1.7 * 1.10929019;
+    const CPUCT: f32 = 1.7 * 0.70710678;
+    pub const EVAL_SCALE: f32 = 187.5;
 
     pub fn new() -> Self {
         Self {

--- a/src/search.rs
+++ b/src/search.rs
@@ -54,8 +54,8 @@ pub struct MCTS {
 }
 
 impl MCTS {
-    const ROOT_CPUCT: f32 = 1.6 * 1.10929019;
-    const CPUCT: f32 = 1.6 * 0.70710678;
+    const ROOT_CPUCT: f32 = 1.5 * 1.10929019;
+    const CPUCT: f32 = 1.5 * 0.70710678;
     pub const EVAL_SCALE: f32 = 187.5;
 
     pub fn new() -> Self {

--- a/src/search.rs
+++ b/src/search.rs
@@ -54,8 +54,8 @@ pub struct MCTS {
 }
 
 impl MCTS {
-    const ROOT_CPUCT: f32 = 1.9 * 1.10929019;
-    const CPUCT: f32 = 1.9 * 0.70710678;
+    const ROOT_CPUCT: f32 = 1.6 * 1.10929019;
+    const CPUCT: f32 = 1.6 * 0.70710678;
     pub const EVAL_SCALE: f32 = 187.5;
 
     pub fn new() -> Self {

--- a/src/search.rs
+++ b/src/search.rs
@@ -54,8 +54,8 @@ pub struct MCTS {
 }
 
 impl MCTS {
-    const ROOT_CPUCT: f32 = 1.5 * 1.10929019;
-    const CPUCT: f32 = 1.5 * 0.70710678;
+    const ROOT_CPUCT: f32 = 1.66393528;
+    const CPUCT: f32 = 1.06066017;
     pub const EVAL_SCALE: f32 = 187.5;
 
     pub fn new() -> Self {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -12,6 +12,7 @@ use crate::{
         Board, Move,
     },
     policy,
+    search::MCTS,
 };
 
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -55,7 +56,7 @@ impl Score {
             Self::Win(dist) => format!("mate {}", (*dist + 1) / 2),
             Self::Draw => format!("cp 0"),
             Self::Loss(dist) => format!("mate -{}", *dist / 2),
-            Self::Normal(score) => format!("cp {}", sigmoid_inv(*score, 400.0).round()),
+            Self::Normal(score) => format!("cp {}", sigmoid_inv(*score, MCTS::EVAL_SCALE).round()),
         }
     }
 }
@@ -66,7 +67,9 @@ impl fmt::Display for Score {
             Self::Win(dist) => write!(f, "win {} plies", *dist),
             Self::Draw => write!(f, "draw"),
             Self::Loss(dist) => write!(f, "loss {} plies", *dist),
-            Self::Normal(score) => write!(f, "cp {}", sigmoid_inv(*score, 400.0).round()),
+            Self::Normal(score) => {
+                write!(f, "cp {}", sigmoid_inv(*score, MCTS::EVAL_SCALE).round())
+            }
         }
     }
 }


### PR DESCRIPTION
use eval scale from tuning + increase cpuct to account for this
```
Elo   | 22.84 +- 13.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 10.00]
Games | N: 1386 W: 391 L: 300 D: 695
Penta | [34, 152, 258, 187, 62]
```
https://mcthouacbb.pythonanywhere.com/test/978/

Bench: 8337196